### PR TITLE
The usual pre-release minutia

### DIFF
--- a/.github/workflows/cldf-validation.yml
+++ b/.github/workflows/cldf-validation.yml
@@ -1,0 +1,32 @@
+name: CLDF-validation
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.12]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest-cldf
+    - name: Test with pytest
+      run: |
+        pytest --cldf-metadata=cldf/lexicon-metadata.json test.py
+        pytest --cldf-metadata=cldf/phonemes-metadata.json test.py
+        pytest --cldf-metadata=cldf/phonology-metadata.json test.py
+        pytest --cldf-metadata=cldf/wordlist-metadata.json test.py

--- a/analysis/comrie-query/code.py
+++ b/analysis/comrie-query/code.py
@@ -33,7 +33,7 @@ with open("data.txt", encoding='utf8') as f:
                     concept,
                     mappings[0][0],
                     mappings[0][1]
-                    ]]
+                ]]
 
 # cursor.execute("insert into LanguageTable(cldf_id) values ('proto');")
 # for i, row in enumerate(data):
@@ -93,8 +93,8 @@ elif OUT == 'extended.sql':
 print(tabulate(
     table[:10],
     tablefmt="pipe",
-    headers=header)
-    )
+    headers=header,
+))
 
 with open('matches.tsv', 'w', encoding='utf8', newline='') as f:
     writer = csv.writer(f, delimiter='\t')

--- a/analysis/word_families/cognateset_diversity.py
+++ b/analysis/word_families/cognateset_diversity.py
@@ -25,8 +25,8 @@ header = ["Cognate", "Concept", "Family", "Frequency"]
 print(tabulate(
     table[:10],
     tablefmt="pipe",
-    headers=header)
-    )
+    headers=header,
+))
 
 with open('cognateset_diversity.tsv', 'w', encoding='utf8', newline='') as f:
     writer = csv.writer(f, delimiter='\t')

--- a/analysis/word_families/colexifications.py
+++ b/analysis/word_families/colexifications.py
@@ -25,8 +25,8 @@ header = ["Count", "Language", "Glottocode", "Family", "Form"]
 print(tabulate(
     table[:10],
     tablefmt="pipe",
-    headers=header)
-    )
+    headers=header,
+))
 
 with open('colex.tsv', 'w', encoding='utf8', newline='') as f:
     writer = csv.writer(f, delimiter='\t')

--- a/analysis/word_families/lb_release.py
+++ b/analysis/word_families/lb_release.py
@@ -25,8 +25,8 @@ header = ["Count", "Language", "Glottocode", "Longitude", "Latitude", "Family"]
 print(tabulate(
     table[:10],
     tablefmt="pipe",
-    headers=header)
-    )
+    headers=header,
+))
 
 with open('lb_1.tsv', 'w', encoding='utf8', newline='') as f:
     writer = csv.writer(f, delimiter='\t')

--- a/lexibank_analysed_commands/correlations.py
+++ b/lexibank_analysed_commands/correlations.py
@@ -13,7 +13,7 @@ from cltoolkit.features import FEATURES
 from cldfzenodo import Record
 from clldutils.clilib import Table, add_format
 
-from lexibank_lexibank_analysed import Dataset as LB, CLTS_2_1
+from lexibank_lexibank_analysed import Dataset as LB, CLTS_2_3
 
 
 def register(parser):
@@ -30,7 +30,7 @@ def run(args):
     lba = LB()
 
     args.log.info('Loading data ...')
-    clts = CLTS(lba.raw_dir / CLTS_2_1[1])
+    clts = CLTS(lba.raw_dir / CLTS_2_3[1])
     clts2phoible = clts.transcriptiondata_dict["phoible"]
 
     # WALS Online v2020.1

--- a/lexibank_lexibank_analysed.py
+++ b/lexibank_lexibank_analysed.py
@@ -379,7 +379,7 @@ class Dataset(BaseDataset):
                     args.log.warn(f"{language.name} / {language.dataset} / {language.glottocode}")
                     return False
             else:
-                langs['Incollections'] = langs['Incollections'] + [collection]
+                langs['Incollections'].append(collection)
             if language.id not in visited:
                 for cid in ["ClicsCore", "LexiCore", "CogCore", "ProtoCore"]:
                     try:
@@ -596,7 +596,7 @@ class Dataset(BaseDataset):
             args.log.info("write information on selected languages")
             for lid, language in languages.items():
                 if lid in best_languages:
-                    languages[lid]["Incollections"] += ["Selexion"]
+                    languages[lid]["Incollections"].append("Selexion")
                     collstats["Selexion"]["Glottocodes"].add(best_languages[lid].glottocode)
                     collstats["Selexion"]["Varieties"] += 1
                     collstats["Selexion"]["Forms"] += len(best_languages[lid].forms)

--- a/lexibank_lexibank_analysed.py
+++ b/lexibank_lexibank_analysed.py
@@ -163,7 +163,7 @@ class Dataset(BaseDataset):
                 shutil.rmtree(dest)
 
             args.log.info(f"Downloading {dataset}")
-            record = cldfzenodoapi.get_record(row["Zenodo"]) 
+            record = cldfzenodoapi.get_record(row["Zenodo"])
             # check if record is most recent one
             rec_new = record.from_concept_doi(record.concept_doi)
             if rec_new.doi != record.doi:
@@ -188,21 +188,19 @@ class Dataset(BaseDataset):
                 meta = json.load(f)
             description = meta["citation"]
             # create bibtex and write to new file
-            bib = dict(author=" and ".join(record.creators),
-                    title=record.title,
-                    publisher="Zenodo",
-                    year=record.year,
-                    address="Geneva",
-                    doi=record.doi)
+            bib = dict(
+                author=" and ".join(record.creators),
+                title=record.title,
+                publisher="Zenodo",
+                year=record.year,
+                address="Geneva",
+                doi=record.doi)
             if editors:
                 bib["editor"] = " and ".join(editors)
             if description:
                 bib["citation"] = description
 
-            sources.add(pycldf.Source(
-                    "book",
-                    row["ID"],
-                    **bib))
+            sources.add(pycldf.Source("book", row["ID"], **bib))
 
             # check if source is in sources
             for src_key in row["Source"].split(" "):
@@ -252,7 +250,7 @@ class Dataset(BaseDataset):
             {'name': 'Forms', 'datatype': 'integer', 'dc:description': 'Number of forms'},
             {'name': "FormsWithSounds", "datatype": "integer", "dc:description": "Number of forms with sounds"},
             {'name': 'Concepts', 'datatype': 'integer', 'dc:description': 'Number of concepts'},
-            {'name': 'Incollections', 'datatype': "string", "separator": " ", 
+            {'name': 'Incollections', 'datatype': "string", "separator": " ",
              "dc:description": "Subselections of Lexibank"},
             'Subgroup',
             'Family',
@@ -277,11 +275,11 @@ class Dataset(BaseDataset):
             'Senses',
             'Forms',
             {
-                "name": 'Source', 
+                "name": 'Source',
                 "propertyUrl": "http://cldf.clld.org/v1.0/terms.rdf#source",
                 "datatype": "string",
-                "separator": ";"
-                },
+                "separator": ";",
+            },
         )
         writer.cldf.add_foreign_key('ContributionTable', 'Collection_IDs', 'collections.csv', 'ID')
 
@@ -314,7 +312,7 @@ class Dataset(BaseDataset):
     def cmd_makecldf(self, args):
         cid2gls = {c.id: c.gloss for c in
                    self.concepticon.conceptsets.values()}
-        languoids = self.glottolog.cached_languoids 
+        languoids = self.glottolog.cached_languoids
         visited = set()
         collstats = collections.OrderedDict()
         for cid, (desc, name) in COLLECTIONS.items():
@@ -464,8 +462,8 @@ class Dataset(BaseDataset):
                     duplicates = set()
                     for form in language.forms_with_sounds:
                         form_check = "{0}-{1}".format(
-                                form.concept.concepticon_id if form.concept else "",
-                                str(form.sounds))
+                            form.concept.concepticon_id if form.concept else "",
+                            str(form.sounds))
                         if form.concept and \
                                 form.concept.concepticon_id and \
                                 form.concept.concepticon_id in cid2gls and \
@@ -488,7 +486,7 @@ class Dataset(BaseDataset):
                                 SCA_Sound_Classes="".join(
                                     clts.soundclass("sca")(form.sounds)),
                                 Source=self.dataset_meta[language.dataset]["ID"],
-                                )
+                            )
                             visited_concepts.add(cgls)
                         elif form_check in duplicates:
                             excluded.append(form)
@@ -499,11 +497,11 @@ class Dataset(BaseDataset):
                 f.write("--- | --- | --- | --- | ---\n")
                 for form in excluded:
                     f.write(" | ".join([
-                        form.id, 
+                        form.id,
                         form.language.name,
                         form.concept.concepticon_gloss,
                         form.form, str(form.sounds)]) + "\n")
-                    
+
             args.log.info('added lexibank forms')
             # retrieve central concept from Rzymski concept list
             central_concepts = {

--- a/lexibank_lexibank_analysed.py
+++ b/lexibank_lexibank_analysed.py
@@ -168,7 +168,7 @@ class Dataset(BaseDataset):
             rec_new = record.from_concept_doi(record.concept_doi)
             if rec_new.doi != record.doi:
                 record = rec_new
-                args.log.warn(f"DOI for datasets {row["ID"]} is not the latest version!")
+                args.log.warn(f'DOI for datasets {row["ID"]} is not the latest version!')
             record.download(dest)
 
             # load zenodo info to make a new bibtex and doi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     license='MIT',
     url='https://github.com/lexibank/lexibank-analysed',
     py_modules=['lexibank_lexibank_analysed'],
-    packages=find_packages(where='.'),
+    packages=['lexibank_analysed_commands'],
     include_package_data=True,
     zip_safe=False,
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         ],
     },
     platforms='any',
-    python_requires='>=3.6',
+    python_requires='>=3.8',
     install_requires=[
         'collabutils[googlesheets]',
         'cldfbench>=1.7.2',
@@ -63,10 +63,12 @@ setup(
         'Natural Language :: English',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy'
     ],


### PR DESCRIPTION
 * support python 3.8 (we don't *need* to do that but it was a 2-character fix so might as well)
 * code style, linting, etc.
 * fix the broken *cldfbench* command
 * wanted to update the github action but there wasn't any – there is now
 * make pip shut up about that stupid toml file they require now