### PR TITLE
Invalid ids in frequencies.csv

### DIFF
--- a/.github/workflows/cldf-validation.yml
+++ b/.github/workflows/cldf-validation.yml
@@ -24,7 +24,7 @@ jobs:
         pip install pytest-cldf
     - name: Validate lexicon
       run: |
-        pytest --cldf-metadata=cldf/lexicon-metadata.json test.py
+        pytest -k test_lexicon
 
   validate-phonemes:
     runs-on: ubuntu-latest
@@ -43,7 +43,7 @@ jobs:
         pip install pytest-cldf
     - name: Validate phonemes
       run: |
-        pytest --cldf-metadata=cldf/phonemes-metadata.json test.py
+        pytest -k test_phonemes
 
   validate-phonology:
     runs-on: ubuntu-latest
@@ -62,7 +62,7 @@ jobs:
         pip install pytest-cldf
     - name: Validate phonology
       run: |
-        pytest --cldf-metadata=cldf/phonology-metadata.json test.py
+        pytest -k test_phonology
 
   validate-wordlist:
     runs-on: ubuntu-latest
@@ -81,4 +81,4 @@ jobs:
         pip install pytest-cldf
     - name: Validate wordlist
       run: |
-        pytest --cldf-metadata=cldf/wordlist-metadata.json test.py
+        pytest -k test_wordlist

--- a/lexibank_lexibank_analysed.py
+++ b/lexibank_lexibank_analysed.py
@@ -610,7 +610,7 @@ class Dataset(BaseDataset):
                 ))
                 for lid, freq in sorted(occurrences.items()):
                     writer.objects['ValueTable'].append(dict(
-                        ID='f{lid}-{clts_id}',
+                        ID=f'{lid}-{clts_id}',
                         Language_ID=lid,
                         Parameter_ID=clts_id,
                         Value=freq,

--- a/test.py
+++ b/test.py
@@ -1,6 +1,25 @@
-from pycldf import iter_datasets
+from pycldf import iter_datasets, Dataset
 
 
-def test_valid(cldf_dataset, cldf_logger):
-    for ds in iter_datasets(cldf_dataset.directory):
-        assert ds.validate(log=cldf_logger)
+def test_lexicon(cldf_dataset, cldf_logger):
+    md = cldf_dataset.directory / 'lexicon-metadata.json'
+    ds = Dataset.from_metadata(md)
+    assert ds.validate(log=cldf_logger)
+
+
+def test_phonemes(cldf_dataset, cldf_logger):
+    md = cldf_dataset.directory / 'phonemes-metadata.json'
+    ds = Dataset.from_metadata(md)
+    assert ds.validate(log=cldf_logger)
+
+
+def test_phonology(cldf_dataset, cldf_logger):
+    md = cldf_dataset.directory / 'phonology-metadata.json'
+    ds = Dataset.from_metadata(md)
+    assert ds.validate(log=cldf_logger)
+
+
+def test_wordlist(cldf_dataset, cldf_logger):
+    md = cldf_dataset.directory / 'wordlist-metadata.json'
+    ds = Dataset.from_metadata(md)
+    assert ds.validate(log=cldf_logger)


### PR DESCRIPTION
 * *frequencies.csv* had invalid ids.
 * I fixed the tests so one can see *which* dataset an error comes from

Two remarks:
 * The CI will fail because all cldf data has been deleted from master for some reason
 * The CI didn't catch this due to a bug in *pycldf* (cf. https://github.com/cldf/pycldf/issues/187).  I'm on it.